### PR TITLE
[#4] Modifier extension function 'applyIf' and corresponding unit tests

### DIFF
--- a/app/src/main/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensions.kt
+++ b/app/src/main/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensions.kt
@@ -4,13 +4,14 @@ import androidx.compose.ui.Modifier
 
 
 /**
- * Applies a modifier to the current Modifier if a given condition is true.
+ * Conditionally applies a modifier to the current Modifier.
  *
- * This function checks a given condition and if the condition is true, it applies a specified modifier to the current Modifier.
+ * This function evaluates a given condition. If the condition is true, it applies a specified modifier to the current Modifier.
  * If the condition is false, it returns the current Modifier without any changes.
  *
  * @param conditional A Boolean value representing the condition to check.
- * @param modifierWhenTrue A lambda function with receiver of type Modifier that returns a Modifier. This function is invoked on the current Modifier when the condition is true.
+ * @param whenTrue A lambda function with receiver of type Modifier that returns a Modifier. This function is invoked on the current Modifier when the condition is true.
+ * @param whenFalse A lambda function with receiver of type Modifier that returns a Modifier. This function is invoked on the current Modifier when the condition is false. By default, it returns the current Modifier without any changes.
  *
  * @return A Modifier which is either the current Modifier with the applied changes (if the condition is true) or the current Modifier without any changes (if the condition is false).
  *
@@ -18,9 +19,10 @@ import androidx.compose.ui.Modifier
  * Modifier.applyIf(isSelected) {
  *     border(2.dp, Color.Black)
  * }
- * This sample applies a black border to the Modifier if `isSelected` is true.
+ * This sample applies a black border to the Modifier if `isSelected` is true. If `isSelected` is false, no changes are made to the Modifier.
  */
 inline fun Modifier.applyIf(
     conditional: Boolean,
-    modifierWhenTrue: Modifier.() -> Modifier,
-): Modifier = if (conditional) then(modifierWhenTrue(Modifier)) else this
+    whenTrue: Modifier.() -> Modifier,
+    whenFalse: Modifier.() -> Modifier = { this }
+): Modifier = if (conditional) then(whenTrue(Modifier)) else then(whenFalse(Modifier))

--- a/app/src/main/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensions.kt
+++ b/app/src/main/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensions.kt
@@ -1,0 +1,26 @@
+package com.codingboy.composely.ui.extensions
+
+import androidx.compose.ui.Modifier
+
+
+/**
+ * Applies a modifier to the current Modifier if a given condition is true.
+ *
+ * This function checks a given condition and if the condition is true, it applies a specified modifier to the current Modifier.
+ * If the condition is false, it returns the current Modifier without any changes.
+ *
+ * @param conditional A Boolean value representing the condition to check.
+ * @param modifierWhenTrue A lambda function with receiver of type Modifier that returns a Modifier. This function is invoked on the current Modifier when the condition is true.
+ *
+ * @return A Modifier which is either the current Modifier with the applied changes (if the condition is true) or the current Modifier without any changes (if the condition is false).
+ *
+ * @sample
+ * Modifier.applyIf(isSelected) {
+ *     border(2.dp, Color.Black)
+ * }
+ * This sample applies a black border to the Modifier if `isSelected` is true.
+ */
+inline fun Modifier.applyIf(
+    conditional: Boolean,
+    modifierWhenTrue: Modifier.() -> Modifier,
+): Modifier = if (conditional) then(modifierWhenTrue(Modifier)) else this

--- a/app/src/test/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensionsTest.kt
+++ b/app/src/test/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensionsTest.kt
@@ -1,0 +1,29 @@
+package com.codingboy.composely.ui.extensions
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.junit.Assert
+import org.junit.Test
+
+class ComposeExtensionsTest {
+
+    @Test
+    fun applyIfAppliesModifierWhenConditionIsTrue() {
+        val originalModifier = Modifier
+        val newModifier = Modifier.padding(10.dp)
+
+        val result = originalModifier.applyIf(true) { newModifier }
+        Assert.assertNotEquals(result, originalModifier)
+    }
+
+    @Test
+    fun applyIfDoesNotApplyModifierWhenConditionIsFalse() {
+        val originalModifier = Modifier
+        val newModifier = Modifier.padding(10.dp)
+
+        val result = originalModifier.applyIf(false) { newModifier }
+
+        Assert.assertEquals(originalModifier, result)
+    }
+}

--- a/app/src/test/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensionsTest.kt
+++ b/app/src/test/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensionsTest.kt
@@ -13,7 +13,7 @@ class ComposeExtensionsTest {
         val originalModifier = Modifier
         val newModifier = Modifier.padding(10.dp)
 
-        val result = originalModifier.applyIf(true) { newModifier }
+        val result = originalModifier.applyIf(true, { newModifier })
         Assert.assertNotEquals(result, originalModifier)
     }
 
@@ -22,8 +22,28 @@ class ComposeExtensionsTest {
         val originalModifier = Modifier
         val newModifier = Modifier.padding(10.dp)
 
-        val result = originalModifier.applyIf(false) { newModifier }
+        val result = originalModifier.applyIf(false, { newModifier })
 
         Assert.assertEquals(originalModifier, result)
+    }
+
+    @Test
+    fun applyIfAppliesWhenFalseModifierWhenConditionIsFalse() {
+        val originalModifier = Modifier
+        val newModifier = Modifier.padding(10.dp)
+
+        val result = originalModifier.applyIf(false, { originalModifier }, { newModifier })
+
+        Assert.assertEquals(newModifier, result)
+    }
+
+    @Test
+    fun applyIfDoesNotApplyWhenFalseModifierWhenConditionIsTrue() {
+        val originalModifier = Modifier
+        val newModifier = Modifier.padding(10.dp)
+
+        val result = originalModifier.applyIf(true, { newModifier }, { originalModifier })
+
+        Assert.assertEquals(newModifier, result)
     }
 }


### PR DESCRIPTION
**Description:**

This PR implements the `applyIf` extension function for the `Modifier` class in the Jetpack Compose UI toolkit. The function allows a `Modifier` to be conditionally applied based on a boolean condition.

The PR includes the following changes:

1. Addition of the `applyIf` extension function in `ComposeExtensions.kt`.
2. Addition of unit tests for the `applyIf` function in `ComposeExtensionsTest.kt`.

The `applyIf` function checks a given condition and if the condition is true, it applies a specified modifier to the current `Modifier`. If the condition is false, it returns the current `Modifier` without any changes.

The unit tests ensure that the `applyIf` function correctly applies a modification to a `Modifier` based on a boolean condition. The tests cover two scenarios: when the condition is `true` and when it is `false`.

This PR is in response to Issue #4.

**Files changed:**

1. `kotlin/com/codingboy/composely/ui/extensions/ComposeExtensions.kt`
2. `app/src/test/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensionsTest.kt`

**How to test:**

1. Check out to the branch `feature/modifier/applyIf/#4`.
2. Run the unit tests in `ComposeExtensionsTest.kt`.