### PR TITLE
[#1] Add Modifier.capture() functionality

### DIFF
--- a/app/src/main/kotlin/com/codingboy/composely/ui/capture/Capture.kt
+++ b/app/src/main/kotlin/com/codingboy/composely/ui/capture/Capture.kt
@@ -1,0 +1,116 @@
+package com.codingboy.composely.ui.capture
+
+import android.graphics.Picture
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.drawscope.draw
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import com.codingboy.composely.ui.extensions.applyIf
+
+
+/**
+ * Represents the different states of the capturing process.
+ */
+sealed class CapturingProgress {
+    /**
+     * Represents the idle state of the capturing process.
+     */
+    data object Idle : CapturingProgress()
+
+    /**
+     * Represents the capturing state of the capturing process.
+     */
+    data object Capturing : CapturingProgress()
+
+    /**
+     * Represents the captured state of the capturing process.
+     * @property picture The captured snapshot.
+     */
+    data class Captured(val picture: Picture) : CapturingProgress()
+
+    /**
+     * Represents the error state of the capturing process.
+     * @property exception The exception that occurred during the capturing process.
+     */
+    data class Error(val exception: Throwable) : CapturingProgress()
+}
+
+/**
+ * Defines the contract for managing the capturing process.
+ */
+interface CaptureState {
+    /**
+     * The current state of the capturing process.
+     */
+    var progress: CapturingProgress
+
+    /**
+     * Starts the capturing process.
+     */
+    fun capture()
+}
+
+/**
+ * An implementation of the [CaptureState] interface.
+ */
+class CaptureStateImpl : CaptureState {
+    /**
+     * The current state of the capturing process.
+     */
+    override var progress: CapturingProgress by mutableStateOf(CapturingProgress.Idle)
+
+    /**
+     * Starts the capturing process.
+     */
+    override fun capture() {
+        progress = CapturingProgress.Capturing
+    }
+}
+
+/**
+ * Creates and remembers a [CaptureState] object.
+ * @return The created [CaptureState] object.
+ */
+@Composable
+fun rememberCaptureState(): CaptureState {
+    return remember { CaptureStateImpl() }
+}
+
+/**
+ * Captures a snapshot when the [state] is [CapturingProgress.Capturing].
+ * @param state The [CaptureState] object.
+ * @return A new [Modifier] that captures a snapshot.
+ */
+fun Modifier.capture(state: CaptureState): Modifier {
+    return this.applyIf(state.progress == CapturingProgress.Capturing, {
+        try {
+            drawWithCache {
+                val width = this.size.width.toInt()
+                val height = this.size.height.toInt()
+
+                onDrawWithContent {
+                    val picture = Picture()
+
+                    val pictureCanvas = Canvas(picture.beginRecording(width, height))
+                    draw(this, this.layoutDirection, pictureCanvas, this.size) {
+                        this@onDrawWithContent.drawContent()
+                    }
+                    picture.endRecording()
+
+                    drawIntoCanvas { canvas -> canvas.nativeCanvas.drawPicture(picture) }
+                    state.progress = CapturingProgress.Captured(picture)
+                }
+            }
+        } catch (e: Exception) {
+            state.progress = CapturingProgress.Error(e)
+            this
+        }
+    })
+}

--- a/app/src/main/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensions.kt
+++ b/app/src/main/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensions.kt
@@ -29,6 +29,14 @@ inline fun Modifier.applyIf(
     whenFalse: Modifier.() -> Modifier = { this }
 ): Modifier = if (conditional) then(whenTrue(Modifier)) else then(whenFalse(Modifier))
 
+/**
+ * Converts a Picture object to a Bitmap.
+ *
+ * This function creates a Bitmap with the same dimensions as the Picture. It then draws the Picture onto a Canvas,
+ * which is backed by the Bitmap. The resulting Bitmap is returned.
+ *
+ * @return A Bitmap representation of the Picture.
+ */
 fun Picture.toBitmap(): Bitmap {
     val bitmap = Bitmap.createBitmap(
         this.width,

--- a/app/src/main/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensions.kt
+++ b/app/src/main/kotlin/com/codingboy/composely/ui/extensions/ComposeExtensions.kt
@@ -1,5 +1,7 @@
 package com.codingboy.composely.ui.extensions
 
+import android.graphics.Bitmap
+import android.graphics.Picture
 import androidx.compose.ui.Modifier
 
 
@@ -26,3 +28,15 @@ inline fun Modifier.applyIf(
     whenTrue: Modifier.() -> Modifier,
     whenFalse: Modifier.() -> Modifier = { this }
 ): Modifier = if (conditional) then(whenTrue(Modifier)) else then(whenFalse(Modifier))
+
+fun Picture.toBitmap(): Bitmap {
+    val bitmap = Bitmap.createBitmap(
+        this.width,
+        this.height,
+        Bitmap.Config.ARGB_8888
+    )
+
+    val canvas = android.graphics.Canvas(bitmap)
+    canvas.drawPicture(this)
+    return bitmap
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.0-beta02"
+agp = "8.5.0"
 kotlin = "1.9.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"
@@ -7,7 +7,7 @@ junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.8.1"
 activityCompose = "1.9.0"
-composeBom = "2023.08.00"
+composeBom = "2024.06.00"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
This PR addresses Issue #1.

The `capture` Modifier allows a `Modifier` to capture its contents as a Picture, which can then be converted to a Bitmap.
This PR also includes an extension function `Picture.toBitmap()`, which can convert a Picture to a Bitmap.